### PR TITLE
Advanced parameter creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Or install it yourself as:
 
 ## Usage
 
+### Basic
+
 RSpec APIBlueprint Formatter not surprisingly generates output that conforms to the [APIBlueprint spec](https://apiblueprint.org/). RSpec APIBlueprint Formatter makes some simplifying assumption and obviously falls short of manually crafted API docs. However, this can be a very efficient way to give your API consumers an easy to browse reference with basically 0 costs.
 
 Effectively what the RSpec APIBlueprint Formatter will do is render tests you tag with `:apidoc` with their request parameters and response body and status. You will need to also tag your tests with (usually in parent context/describe blocks):
@@ -45,6 +47,7 @@ resource_group: 'Resource Group Name',
 resource: 'Resource Name [/path/to/resouce]',
 action: 'Retrieve list of resource [HTTP_VERB]'
 action_description: 'Some accurate, verbose description of the action'
+action_parameters: {parameter: { options: {} } }
 ````
 
 There are some additional restrictions:
@@ -61,12 +64,126 @@ task generate_api_docs: :environment do
 end
 ````
 
+### Parameters
+
+By default, the Request parameters are printed out as the given parameters in the specs. You can add more information about them by using the `action_parameters` metadata. The formatter supports most of the options for the [API Blueprint URL parameters](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#uri-parameters-section). A few examples below:
+
+#### Standard parameter with description
+
+Spec - general:
+
+```ruby
+let (:action_parameters) do
+  {
+    id: {description: 'Id of a post'}
+  }
+end
+
+RSpec.describe 'POST /do_something', action_parameters: action_parameters, resource_group: 'Resources', resource: 'Resource', action: 'Do something', action_description: 'Do something' do
+
+end
+```
+
+Generates:
+
+```apib
++ Parameters
+    + id - Id of a post.
+```
+
+#### Parameter with description and type
+
+Spec:
+
+```ruby
+let (:action_parameters) do
+  {
+    id: {description: 'Id of a post', type: :number}
+  }
+end
+```
+
+Generates:
+
+```apib
++ Parameters
+    + id (number) - Id of a post.
+```
+
+#### Parameter with description, type and optional flag
+
+Spec:
+
+```ruby
+let (:action_parameters) do
+  {
+    id: {description: 'Id of a post', type: :number, optional: true}
+  }
+end
+```
+
+Generates:
+
+```apib
++ Parameters
+    + id: `1001` (number, optional) - Id of a post.
+```
+
+#### Parameter with description, type and optional flag with default value
+
+Spec:
+
+```ruby
+let (:action_parameters) do
+  {
+    id: {description: 'Id of a post', type: :number, optional: true, default: 20}
+  }
+end
+```
+
+Generates:
+
+```apib
++ Parameters
+    + id: `1001` (number, optional) - Id of a post.
+        + Default: `20`
+```
+
+#### Enum parameter with description
+
+Spec:
+
+```ruby
+let (:action_parameters) do
+  {
+    id: {description: 'Id of a post', type: 'enum[string]', members: %w(A B C)}
+  }
+end
+```
+
+Generates:
+
+```apib
++ Parameters
+    + id (enum[string])
+
+        Id of a Post
+
+        + Members
+            + `A`
+            + `B`
+            + `C`
+```
+
+#### Other notes
+
+- `<example value>` is not supported because it doesn't make sense with RSpec generated response bodies (already some example values there).
+- `required` flag is not supported - it is the default anyway.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/nambrot/rspec-api-blueprint-formatter. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](contributor-covenant.org) code of conduct.
 
-
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/lib/api_blueprint.rb
+++ b/lib/api_blueprint.rb
@@ -1,6 +1,11 @@
 require 'rspec'
 require 'rspec/core/formatters/base_formatter'
 
+require 'api_blueprint/example_formatter'
+
+module ApiBlueprintFormatter
+end
+
 class ApiBlueprint < RSpec::Core::Formatters::BaseFormatter
   VERSION = "0.1.3"
   RSpec::Core::Formatters.register self, :example_passed, :example_started, :stop
@@ -94,20 +99,7 @@ class ApiBlueprint < RSpec::Core::Formatters::BaseFormatter
   end
 
   def print_example(example_description, example_metadata)
-    output.puts "+ Request #{example_description}\n" \
-      "\n" \
-      "        #{example_metadata[:request][:parameters]}\n" \
-      "        \n" \
-      "        Location: #{example_metadata[:location]}\n" \
-      "        Source code:\n" \
-      "        \n" \
-      "#{indent_lines(8, example_metadata[:source])}\n" \
-      "\n"
-
-    output.puts "+ Response #{example_metadata[:response][:status]} (#{example_metadata[:request][:format]})\n" \
-      "\n" \
-      "        #{example_metadata[:response][:body]}\n" \
-      "\n"
+    output.puts ApiBlueprintFormatter::ExampleFormatter.new(example_description, example_metadata).print
   end
 
   # To include the descriptions of all the contexts that are below the action
@@ -120,12 +112,5 @@ class ApiBlueprint < RSpec::Core::Formatters::BaseFormatter
     else
       [example_metadata[:description]] + description_array_from(parent)
     end
-  end
-
-  def indent_lines(number_of_spaces, string)
-    string
-      .split("\n")
-      .map { |a| a.prepend(' ' * number_of_spaces) }
-      .join("\n")
   end
 end

--- a/lib/api_blueprint.rb
+++ b/lib/api_blueprint.rb
@@ -1,13 +1,12 @@
 require 'rspec'
 require 'rspec/core/formatters/base_formatter'
 
+require 'api_blueprint/version'
+require 'api_blueprint/base_formatter'
 require 'api_blueprint/example_formatter'
-
-module ApiBlueprintFormatter
-end
+require 'api_blueprint/action_formatter'
 
 class ApiBlueprint < RSpec::Core::Formatters::BaseFormatter
-  VERSION = "0.1.3"
   RSpec::Core::Formatters.register self, :example_passed, :example_started, :stop
 
   def initialize(output)
@@ -39,6 +38,7 @@ class ApiBlueprint < RSpec::Core::Formatters::BaseFormatter
           metadata[:resource] => {
             metadata[:action] => {
               description: metadata[:action_description],
+              parameters: metadata[:action_parameters],
               examples: {
                 description => {
                   request: {
@@ -89,17 +89,14 @@ class ApiBlueprint < RSpec::Core::Formatters::BaseFormatter
     actions.each &method(:print_action)
   end
 
-  def print_action(action_name, action_meta_data)
-    output.puts "## #{action_name}\n" \
-                "\n" \
-                "#{action_meta_data[:description]}\n" \
-                "\n" \
+  def print_action(action_name, action_metadata)
+    output.puts ApiBlueprintFormatter::ActionFormatter.new(action_name, action_metadata).format
 
-    action_meta_data[:examples].each &method(:print_example)
+    action_metadata[:examples].each &method(:print_example)
   end
 
   def print_example(example_description, example_metadata)
-    output.puts ApiBlueprintFormatter::ExampleFormatter.new(example_description, example_metadata).print
+    output.puts ApiBlueprintFormatter::ExampleFormatter.new(example_description, example_metadata).format
   end
 
   # To include the descriptions of all the contexts that are below the action

--- a/lib/api_blueprint/action_formatter.rb
+++ b/lib/api_blueprint/action_formatter.rb
@@ -1,0 +1,93 @@
+module ApiBlueprintFormatter
+  # Parses example metadata for Actions and outputs markdown in
+  # accordance with the API Blueprint spec.
+  #
+  # Spec: https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#def-action-section
+  class ActionFormatter < BaseFormatter
+    attr_reader :action_metadata, :action_name
+
+    def initialize(action_name, action_metadata)
+      @action_name = action_name
+      @action_metadata = action_metadata
+      @parameters = action_metadata[:parameters] || []
+    end
+
+    def format
+      output = []
+      output << "## #{action_name}"
+      output << ''
+      output << action_metadata[:description].to_s
+      output << ''
+      output += format_parameters
+      output << ''
+
+      output.join("\n")
+    end
+
+    private
+
+    def format_parameters
+      return [] if @parameters.empty?
+
+      output = ['']
+      output << '+ Parameters'
+      @parameters.each_pair do |param, data|
+        output += format_param(param, data)
+      end
+      output << ''
+
+          output
+    end
+
+    def format_param(param, data)
+      out = []
+      out << indent_lines(4, action_header(param, data))
+
+      if multiline_description(param)
+        out << ''
+        out << indent_lines(8, data[:description])
+        out << ''
+      end
+
+      out << indent_lines(8, "+ Default: #{data[:default]}") if data[:default]
+      out += format_members(param)
+
+      out
+    end
+
+    def multiline_description(param)
+      members(param).size > 0
+    end
+
+    def action_header(param, data)
+      param_signature = "#{param}#{param_attributes_string(data)}"
+      multiline_description = !members(param).empty?
+
+      header = "+ #{param_signature}"
+      header += " - #{data[:description]}" unless multiline_description
+      header
+    end
+
+    def param_attributes_string(data)
+      optional = data[:optional] ? 'optional' : nil
+      param_attributes = [data[:type], optional].compact
+
+      " (#{param_attributes.join(', ')})" unless param_attributes.empty?
+    end
+
+    def members(param)
+      @action_metadata[:parameters][param].fetch(:members, [])
+    end
+
+    def format_members(param)
+      out = []
+      unless members(param).empty?
+        out << indent_lines(8, '+ Members')
+        members(param).each do |member|
+          out << indent_lines(12, "+ `#{member}`")
+        end
+      end
+      out
+    end
+  end
+end

--- a/lib/api_blueprint/base_formatter.rb
+++ b/lib/api_blueprint/base_formatter.rb
@@ -1,0 +1,20 @@
+module ApiBlueprintFormatter
+  # Base for other formatters, providing utility methods
+  class BaseFormatter
+    protected
+
+    def indent_lines(number_of_spaces, string)
+      string
+        .split("\n")
+        .map { |a| a.prepend(' ' * number_of_spaces) }
+        .join("\n")
+    end
+
+    # Change certain characters that might come up in example names
+    # but do not play well with the API specs.
+    # Example: 'Test for [value]' -> 'Test for {value}'
+    def sanitize_api_identifier(name)
+      name.gsub(/[\[\]]/, '[' => '{', ']' => '}')
+    end
+  end
+end

--- a/lib/api_blueprint/example_formatter.rb
+++ b/lib/api_blueprint/example_formatter.rb
@@ -1,0 +1,40 @@
+module ApiBlueprintFormatter
+  class ExampleFormatter
+    attr_reader :example_metadata
+
+    def initialize(example_description, example_metadata)
+      @example_description, @example_metadata = example_description, example_metadata
+    end
+
+    def format
+      out = ''
+      out << "+ Request #{example_description}\n" \
+      "\n" \
+      "        #{example_metadata[:request][:parameters]}\n" \
+      "\n" \
+      "        Location: #{example_metadata[:location]}\n" \
+      "        Source code:\n" \
+      "\n" \
+      "#{indent_lines(8, example_metadata[:source])}\n" \
+      "\n"
+
+      out << "+ Response #{example_metadata[:response][:status]} (#{example_metadata[:request][:format]})\n" \
+      "\n" \
+      "        #{example_metadata[:response][:body]}\n" \
+      "\n"
+    end
+
+    def example_description
+      @example_description.gsub(/[\[\]]/, '['=>'{', ']'=>'}')
+    end
+
+    private
+
+    def indent_lines(number_of_spaces, string)
+      string
+          .split("\n")
+          .map { |a| a.prepend(' ' * number_of_spaces) }
+          .join("\n")
+    end
+  end
+end

--- a/lib/api_blueprint/example_formatter.rb
+++ b/lib/api_blueprint/example_formatter.rb
@@ -1,14 +1,32 @@
 module ApiBlueprintFormatter
-  class ExampleFormatter
+  # Parses example metadata for Examples (Request+Response) and outputs
+  # markdown in accordance with the API Blueprint spec.
+  #
+  # Specs:
+  #   - https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#def-request-section
+  #   - https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#response-section
+  class ExampleFormatter < BaseFormatter
     attr_reader :example_metadata
 
     def initialize(example_description, example_metadata)
-      @example_description, @example_metadata = example_description, example_metadata
+      @example_description = example_description
+      @example_metadata = example_metadata
     end
 
     def format
       out = ''
-      out << "+ Request #{example_description}\n" \
+      out << format_request
+      out << format_response
+    end
+
+    def example_description
+      sanitize_api_identifier(@example_description)
+    end
+
+    private
+
+    def format_request
+      "+ Request #{example_description}\n" \
       "\n" \
       "        #{example_metadata[:request][:parameters]}\n" \
       "\n" \
@@ -17,24 +35,13 @@ module ApiBlueprintFormatter
       "\n" \
       "#{indent_lines(8, example_metadata[:source])}\n" \
       "\n"
+    end
 
-      out << "+ Response #{example_metadata[:response][:status]} (#{example_metadata[:request][:format]})\n" \
+    def format_response
+      "+ Response #{example_metadata[:response][:status]} (#{example_metadata[:request][:format]})\n" \
       "\n" \
       "        #{example_metadata[:response][:body]}\n" \
       "\n"
-    end
-
-    def example_description
-      @example_description.gsub(/[\[\]]/, '['=>'{', ']'=>'}')
-    end
-
-    private
-
-    def indent_lines(number_of_spaces, string)
-      string
-          .split("\n")
-          .map { |a| a.prepend(' ' * number_of_spaces) }
-          .join("\n")
     end
   end
 end

--- a/lib/api_blueprint/version.rb
+++ b/lib/api_blueprint/version.rb
@@ -1,0 +1,3 @@
+module ApiBlueprintFormatter
+  VERSION = '0.2.0'
+end

--- a/rspec-api-blueprint-formatter.gemspec
+++ b/rspec-api-blueprint-formatter.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "rspec-api-blueprint-formatter"
-  spec.version       = '0.1.3'
+  spec.version       = ApiBlueprint::VERSION
   spec.authors       = ["Nam Chu Hoai"]
   spec.email         = ["nambrot@googlemail.com"]
 

--- a/rspec-api-blueprint-formatter.gemspec
+++ b/rspec-api-blueprint-formatter.gemspec
@@ -2,9 +2,11 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require('api_blueprint/version')
+
 Gem::Specification.new do |spec|
   spec.name          = "rspec-api-blueprint-formatter"
-  spec.version       = ApiBlueprint::VERSION
+  spec.version       = ApiBlueprintFormatter::VERSION
   spec.authors       = ["Nam Chu Hoai"]
   spec.email         = ["nambrot@googlemail.com"]
 

--- a/spec/api_blueprint/action_formatter_spec.rb
+++ b/spec/api_blueprint/action_formatter_spec.rb
@@ -1,0 +1,123 @@
+require 'spec_helper'
+
+require 'json'
+
+RSpec.describe ApiBlueprintFormatter::ActionFormatter do
+  subject { described_class.new(action_name, action_metadata).format }
+
+  let(:action_name) { 'Standard Action [GET /api/v0/resource]' }
+  let(:action_metadata) { { description: action_description, parameters: action_parameters } }
+
+  let(:action_description) { 'Lorem ipsum et dolor' }
+  let(:action_parameters) { {} }
+
+  describe '#format' do
+    context 'with standard meta-data' do
+      it 'formats properly' do
+        is_expected.to eq "## Standard Action [GET /api/v0/resource]\n\nLorem ipsum et dolor\n\n"
+      end
+    end
+
+    context 'with parameters' do
+      let(:action_header) { "## #{action_name}\n\n#{action_description}\n" }
+
+      context 'only descriptive params' do
+        let(:action_parameters) do
+          {
+            id: { description: 'Id of a post' }
+          }
+        end
+
+        it do
+          is_expected.to eq <<-EOF
+#{action_header}
+
++ Parameters
+    + id - Id of a post
+
+          EOF
+        end
+      end
+
+      context 'descriptive param with type' do
+        let(:action_parameters) do
+          {
+            id: { description: 'Id of a post', type: :number }
+          }
+        end
+
+        it do
+          is_expected.to eq <<-EOF
+#{action_header}
+
++ Parameters
+    + id (number) - Id of a post
+
+          EOF
+        end
+      end
+
+      context 'descriptive param with type and optionality' do
+        let(:action_parameters) do
+          {
+            amount: { description: 'Id of a post', type: :number, optional: true }
+          }
+        end
+
+        it do
+          is_expected.to eq <<-EOF
+#{action_header}
+
++ Parameters
+    + amount (number, optional) - Id of a post
+
+          EOF
+        end
+      end
+
+      context 'descriptive param with: type, optionality, default value' do
+        let(:action_parameters) do
+          {
+            amount: { description: 'Id of a post', type: :number, optional: true, default: 0 }
+          }
+        end
+
+        it do
+          is_expected.to eq <<-EOF
+#{action_header}
+
++ Parameters
+    + amount (number, optional) - Id of a post
+        + Default: 0
+
+          EOF
+        end
+      end
+
+      context 'descriptive param with: enum and members' do
+        let(:action_parameters) do
+          {
+            id: { description: 'Id of a post', type: 'enum[string]', members: %w(A B C) }
+          }
+        end
+
+        it do
+          is_expected.to eq <<-EOF
+#{action_header}
+
++ Parameters
+    + id (enum[string])
+
+        Id of a post
+
+        + Members
+            + `A`
+            + `B`
+            + `C`
+
+          EOF
+        end
+      end
+    end
+  end
+end

--- a/spec/api_blueprint/example_formatter_spec.rb
+++ b/spec/api_blueprint/example_formatter_spec.rb
@@ -69,7 +69,7 @@ EOF
 
         end
       end
-    end
+     end
   end
 
   describe '#example_description' do

--- a/spec/api_blueprint/example_formatter_spec.rb
+++ b/spec/api_blueprint/example_formatter_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+
+require 'json'
+
+RSpec.describe ApiBlueprintFormatter::ExampleFormatter do
+  subject { described_class.new(example_description, example_metadata).format }
+
+  let(:example_description) { "Standard Request" }
+  let(:example_metadata) do
+    {
+        request: request_metadata,
+        response: response_metadata,
+        location: location,
+        source: source
+    }
+  end
+
+  let(:request_metadata) { { parameters: {}, format: 'application/json' } }
+  let(:response_metadata) { { status: 200, body: JSON.generate({a:1, b:2, c:3}) } }
+  let(:location) { "spec/api_blueprint/example_formatter_spec.rb" }
+  let(:source) { "it 'returns standard APi Blueprint format' do\n  ;\nend" }
+
+
+  describe '#format' do
+    context 'with standard meta-data' do
+      it 'formats properly' do
+        is_expected.to eq <<EOF
++ Request Standard Request
+
+        {}
+
+        Location: spec/api_blueprint/example_formatter_spec.rb
+        Source code:
+
+        it 'returns standard APi Blueprint format' do
+          ;
+        end
+
++ Response 200 (application/json)
+
+        {"a":1,"b":2,"c":3}
+
+EOF
+      end
+
+      context 'and with parameters' do
+        context 'from request data' do
+          let(:request_metadata) { { parameters: {'p1': 'v1', 'p2': 'v2'}, format: 'application/json' } }
+
+          it 'formats properly' do
+            is_expected.to eq <<EOF
++ Request Standard Request
+
+        {:p1=>"v1", :p2=>"v2"}
+
+        Location: spec/api_blueprint/example_formatter_spec.rb
+        Source code:
+
+        it 'returns standard APi Blueprint format' do
+          ;
+        end
+
++ Response 200 (application/json)
+
+        {"a":1,"b":2,"c":3}
+
+EOF
+          end
+
+        end
+      end
+    end
+  end
+
+  describe '#example_description' do
+    subject { described_class.new(example_description, example_metadata).example_description }
+
+    context 'when description has non-compliant characters' do
+      let(:example_description) { 'Standard Request for [company]' }
+
+      it 'changes [] to {}' do
+        expect(subject).to eq 'Standard Request for {company}'
+      end
+    end
+  end
+
+end

--- a/spec/rspec/api/blueprint/formatter_spec.rb
+++ b/spec/rspec/api/blueprint/formatter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe ApiBlueprint do
+describe ApiBlueprintFormatter do
   it 'has a version number' do
-    expect(ApiBlueprint::VERSION).not_to be nil
+    expect(ApiBlueprintFormatter::VERSION).not_to be nil
   end
 end


### PR DESCRIPTION
(Feature description in Issue #3)

Apart from the features descibed in #3 I also took the liberty to:

- connect version from gemspec with the class (this is a best practice)
- refactor the `print_example` into a separate class (and add tests)
- sanitize the description for the examples (I had an issue where test with `[` and `]` broke API generation.

Possible notes for the future:

- there's ample possibilities for validation: 
    - not use members without enum
    - not use default without optional
    - default value vs type check