### PR TITLE
Properly handle http method-only action names ('GET', 'POST' etc)

### DIFF
--- a/lib/api_blueprint.rb
+++ b/lib/api_blueprint.rb
@@ -80,7 +80,7 @@ class ApiBlueprint < RSpec::Core::Formatters::BaseFormatter
     end
     output.puts "# #{resource_name}"
 
-    http_verbs = actions.keys.map {|action| action.scan(/\[([A-Z]+).+\]/).flatten[0] }
+    http_verbs = actions.keys.map {|action| action.scan(/(GET|HEAD|POST|PATCH|PUT|DELETE|OPTIONS)/).flatten[0] }
 
     unless http_verbs.length == http_verbs.uniq.length
       raise "Action HTTP verbs are not unique #{actions.keys.inspect} for resource: '#{resource_name}'"

--- a/lib/api_blueprint/version.rb
+++ b/lib/api_blueprint/version.rb
@@ -1,3 +1,3 @@
 module ApiBlueprintFormatter
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
When defining action names according to the [specs](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#definition-9), we should be able to define:

```
## <HTTP request method>  --- this fails
## <identifier> [<HTTP request method>] --- works properly
## <identifier> [<HTTP request method> <URI template>] --- works properly
```

This PR fixes the first case.




