### PR TITLE
Remove line numbers from location

### DIFF
--- a/lib/api_blueprint/example_formatter.rb
+++ b/lib/api_blueprint/example_formatter.rb
@@ -30,11 +30,15 @@ module ApiBlueprintFormatter
       "\n" \
       "        #{example_metadata[:request][:parameters]}\n" \
       "\n" \
-      "        Location: #{example_metadata[:location]}\n" \
+      "        Location: #{format_location}\n" \
       "        Source code:\n" \
       "\n" \
       "#{indent_lines(8, example_metadata[:source])}\n" \
       "\n"
+    end
+
+    def format_location
+      example_metadata[:location].gsub(/:\d+/,'') # remove line numbers from location
     end
 
     def format_response

--- a/lib/api_blueprint/version.rb
+++ b/lib/api_blueprint/version.rb
@@ -1,3 +1,3 @@
 module ApiBlueprintFormatter
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end

--- a/spec/api_blueprint/example_formatter_spec.rb
+++ b/spec/api_blueprint/example_formatter_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ApiBlueprintFormatter::ExampleFormatter do
 
   let(:request_metadata) { { parameters: {}, format: 'application/json' } }
   let(:response_metadata) { { status: 200, body: JSON.generate({a:1, b:2, c:3}) } }
-  let(:location) { "spec/api_blueprint/example_formatter_spec.rb" }
+  let(:location) { "spec/api_blueprint/example_formatter_spec.rb:42" }
   let(:source) { "it 'returns standard APi Blueprint format' do\n  ;\nend" }
 
 


### PR DESCRIPTION
Rationale:
- When moving code around without changing spec functionality, this causes false-positive changes in the documentation (can be quite annoying when you get 50 lines changed without any functional changes)
- The location in terms of file + code source makes it easy to find the source in the spec anyway so no harm done here.